### PR TITLE
Stopped the timer before additional operations.

### DIFF
--- a/BenchmarkMinECS/Program.cs
+++ b/BenchmarkMinECS/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 
 struct Int1
@@ -86,8 +87,10 @@ class Program
 
     static Stopwatch sw = new Stopwatch();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static void Measure(string previousMeasurement = null)
     {
+        sw.Stop();
         if (previousMeasurement != null) Console.WriteLine($"{sw.Elapsed.TotalMilliseconds:00.00} ms {previousMeasurement}");
         sw.Restart();
     }


### PR DESCRIPTION
Stopping the timer before null checking and string concatenation enhances the precision of this benchmark.
Also, inlining the Measure method is better in this case.